### PR TITLE
Remove Slag Use prerequisite from Solid Waste Burial

### DIFF
--- a/prototypes/technology/bulk.lua
+++ b/prototypes/technology/bulk.lua
@@ -1512,7 +1512,7 @@ data:extend(
 			recipe = "slag-burial"
 		}
 	},
-	prerequisites = {"mining-drill_2", "slag-use"},
+	prerequisites = {"mining-drill_2"},
 	unit =
 	{
 		count = 500,


### PR DESCRIPTION
Slag Use requires blue science and is about smelting/cracking slag to recover useful components, which is far more complex and useful than just burying waste in a hole in the ground. This lets players set up complete waste processing much earlier in the game.